### PR TITLE
Add IETF field hasher

### DIFF
--- a/ec/Cargo.toml
+++ b/ec/Cargo.toml
@@ -26,6 +26,8 @@ zeroize = { version = "1", default-features = false, features = ["zeroize_derive
 [dev-dependencies]
 hashbrown = { version = "0.11.1" }
 blake2 = { version = "0.9.2", default-features = false }
+ark-test-curves = { version = "^0.3.0", path = "../test-curves", default-features = false, features = [ "bls12_381_curve"] }
+sha2 = "^0.9"
 
 [features]
 default = []

--- a/ec/src/hashing/README.md
+++ b/ec/src/hashing/README.md
@@ -1,3 +1,0 @@
-# Hash to Curve
-
-This folder provides a trait for `HashToCurve` and a number of implementations of hashing to the curve.

--- a/ec/src/hashing/curve_maps/swu/mod.rs
+++ b/ec/src/hashing/curve_maps/swu/mod.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use ark_ff::bytes::{ToBytes};
+use ark_ff::bytes::ToBytes;
 
 use crate::models::SWModelParameters;
 use ark_ff::{vec::Vec, Field, One, SquareRootField, Zero};
@@ -9,7 +9,6 @@ use ark_std::string::ToString;
 use crate::{
     hashing::{map_to_curve_hasher::MapToCurve, HashToCurveError},
     models::short_weierstrass_jacobian::GroupAffine,
-    AffineCurve,
 };
 
 /// Trait defining the necessary parameters for the SWU hash-to-curve method
@@ -49,7 +48,8 @@ impl<P: SWUParams> MapToCurve<GroupAffine<P>> for SWUMap<P> {
             Some(xi_on_zeta_sqrt) => {
                 if xi_on_zeta_sqrt != P::XI_ON_ZETA_SQRT && xi_on_zeta_sqrt != -P::XI_ON_ZETA_SQRT {
                     return Err(HashToCurveError::MapToCurveError(
-                        "precomputed P::XI_ON_ZETA_SQRT is not what it is supposed to be".to_string(),
+                        "precomputed P::XI_ON_ZETA_SQRT is not what it is supposed to be"
+                            .to_string(),
                     ));
                 }
             }
@@ -74,10 +74,7 @@ impl<P: SWUParams> MapToCurve<GroupAffine<P>> for SWUMap<P> {
     /// Map an arbitrary base field element to a curve point.
     /// Based on
     /// <https://github.com/zcash/pasta_curves/blob/main/src/hashtocurve.rs>.
-    fn map_to_curve(
-        &self,
-        point: P::BaseField,
-    ) -> Result<GroupAffine<P>, HashToCurveError> {
+    fn map_to_curve(&self, point: P::BaseField) -> Result<GroupAffine<P>, HashToCurveError> {
         // 1. tv1 = inv0(Z^2 * u^4 + Z * u^2)
         // 2. x1 = (-B / A) * (1 + tv1)
         // 3. If tv1 == 0, set x1 = B / (Z * A)
@@ -159,14 +156,13 @@ impl<P: SWUParams> MapToCurve<GroupAffine<P>> for SWUMap<P> {
         let num_x = if gx1_square { num_x1 } else { num_x2 };
         let y = if gx1_square { y1 } else { y2 };
 
-        
         let x_affine = num_x / div;
         // 9. If sgn0(u) != sgn0(y), set y = -y
         let mut a = [0u8; 128];
-        let mut b =  [0u8; 128];
+        let mut b = [0u8; 128];
         point.write(&mut a[..]).unwrap();
         y.write(&mut b[..]).unwrap();
-        let y_affine = if a[0] % 2 == b[0] % 2 { -y } else {y};
+        let y_affine = if a[0] % 2 == b[0] % 2 { -y } else { y };
         let point_on_curve = GroupAffine::<P>::new(x_affine, y_affine, false);
         assert!(
             point_on_curve.is_on_curve(),

--- a/ec/src/hashing/curve_maps/wb/mod.rs
+++ b/ec/src/hashing/curve_maps/wb/mod.rs
@@ -25,18 +25,6 @@ type BaseField<MP> = <MP as ModelParameters>::BaseField;
 pub trait WBParams: SWModelParameters + Sized {
     // The isogenous curve should be defined over the same base field but it can have
     // different scalar field type IsogenousCurveScalarField :
-/// Trait defining the necessary parameters for the WB hash-to-curve method
-/// for the curves of Weierstrass form of:
-/// of y^2 = x^3 + a*x + b where b != 0 but `a` can be zero like BLS-381 curve.
-/// From [WB2019]
-///
-/// - [WB19] Wahby, R. S., & Boneh, D. (2019). Fast and simple constant-time
-///   hashing to the bls12-381 elliptic curve. IACR Transactions on
-///   Cryptographic Hardware and Embedded Systems, nil(nil), 154–179.
-///   http://dx.doi.org/10.46586/tches.v2019.i4.154-179
-pub trait WBParams: SWModelParameters + Sized {
-    // The isogenous curve should be defined over the same base field but it can have
-    // different scalar field type IsogenousCurveScalarField :
     type IsogenousCurve: SWUParams<BaseField = BaseField<Self>>;
 
     const PHI_X_NOM: &'static [BaseField<Self>];

--- a/ec/src/hashing/field_hashers/default_hasher.rs
+++ b/ec/src/hashing/field_hashers/default_hasher.rs
@@ -1,0 +1,86 @@
+use ark_ff::{Field, PrimeField};
+use ark_std::vec::Vec;
+
+use crate::hashing::{map_to_curve_hasher::*, *};
+use ark_std::string::ToString;
+use digest::{Update, VariableOutput};
+
+use super::get_len_per_elem;
+
+fn map_bytes_to_field_elem<F: Field>(bz: &[u8]) -> Option<F> {
+    let d: usize = F::extension_degree() as usize;
+    let len_per_elem = bz.len() / d;
+    let mut base_field_elems = Vec::new();
+    for i in 0..d {
+        let val =
+            F::BasePrimeField::from_be_bytes_mod_order(&bz[(i * len_per_elem)..][..len_per_elem]);
+        base_field_elems.push(val);
+    }
+    F::from_base_prime_field_elems(&base_field_elems)
+}
+
+// This field hasher constructs a Hash to Field from a variable output hash
+// function. It handles domains by hashing the input domain into 256 bits, and
+// prefixes these bits to every message it computes the hash of.
+// The state after prefixing the domain is cached.
+pub struct DefaultFieldHasher<H: VariableOutput + Update + Sized + Clone> {
+    // This hasher should already have the domain applied to it.
+    domain_seperated_hasher: H,
+    count: usize,
+}
+
+// Implement HashToField from F and a variable output hash
+impl<F: Field, H: VariableOutput + Update + Sized + Clone> HashToField<F>
+    for DefaultFieldHasher<H>
+{
+    fn new_hash_to_field(domain: &[u8], count: usize) -> Result<Self, HashToCurveError> {
+        // Hardcode security parameter
+        let len_in_bytes = get_len_per_elem::<F, 128>() * F::extension_degree() as usize * count;
+        // Create hasher and map the error type
+        let wrapped_hasher = H::new(len_in_bytes);
+        let mut hasher = match wrapped_hasher {
+            Ok(hasher) => hasher,
+            Err(err) => return Err(HashToCurveError::DomainError(err.to_string())),
+        };
+
+        // DefaultFieldHasher handles domains by hashing them into 256 bits / 32 bytes
+        // using the same hasher. The hashed domain is then prefixed to all
+        // messages that get hashed.
+        let hashed_domain_length_in_bytes = 32;
+        let mut hashed_domain = [0u8; 32];
+        // Create hasher and map the error type
+        let wrapped_domain_hasher = H::new(hashed_domain_length_in_bytes);
+        let mut domain_hasher = match wrapped_domain_hasher {
+            Ok(hasher) => hasher,
+            Err(err) => return Err(HashToCurveError::DomainError(err.to_string())),
+        };
+
+        domain_hasher.update(domain);
+        domain_hasher.finalize_variable(|res| hashed_domain.copy_from_slice(res));
+
+        // Prefix the 32 byte hashed domain to our hasher
+        hasher.update(&hashed_domain);
+        Ok(DefaultFieldHasher {
+            domain_seperated_hasher: hasher,
+            count,
+        })
+    }
+
+    fn hash_to_field(&self, msg: &[u8]) -> Result<Vec<F>, HashToCurveError> {
+        // Clone the hasher, and hash our message
+        let mut cur_hasher = self.domain_seperated_hasher.clone();
+        cur_hasher.update(msg);
+        let mut hashed_bytes = Vec::new();
+        cur_hasher.finalize_variable(|res| hashed_bytes.extend_from_slice(res));
+        // Now separate the hashed bytes according to each field element.
+        let mut result = Vec::with_capacity(self.count);
+        let len_per_elem = hashed_bytes.len() / self.count;
+        for i in 0..self.count {
+            let bz_per_elem = &hashed_bytes[i * len_per_elem..][..len_per_elem];
+            let val = map_bytes_to_field_elem::<F>(bz_per_elem).unwrap();
+            result.push(val);
+        }
+
+        Ok(result)
+    }
+}

--- a/ec/src/hashing/field_hashers/ietf_hasher.rs
+++ b/ec/src/hashing/field_hashers/ietf_hasher.rs
@@ -1,0 +1,128 @@
+use crate::hashing::map_to_curve_hasher::*;
+use crate::hashing::*;
+use ark_ff::{Field, PrimeField};
+use ark_std::vec::Vec;
+use digest::{Digest, FixedOutput};
+
+use super::get_len_per_elem;
+
+/// This field hasher constructs a Hash to Field from a variable output hash function.
+/// It handles domains by hashing the input domain into 256 bits, and prefixes
+/// these bits to every message it computes the hash of.
+/// The state after prefixing the domain is cached.
+///
+/// # Examples
+///
+/// ```
+/// use ark_test_curves::bls12_381::Fq;
+/// use ark_ec::hashing::field_hashers::IETFHasher;
+/// use sha2::Sha256;
+/// use crate::ark_ec::hashing::map_to_curve_hasher::HashToField;
+///
+/// let hasher = <IETFHasher<Sha256> as HashToField<Fq>>::new_hash_to_field(&[1, 2, 3], 2).unwrap();
+/// let field_elements: Vec<Fq> = hasher.hash_to_field(b"Hello, World!").unwrap();
+///
+/// assert_eq!(field_elements.len(), 2);
+/// ```
+pub struct IETFHasher<H: FixedOutput + Digest + Sized + Clone> {
+    hasher: H,
+    count: usize,
+    domain: Vec<u8>,
+    len_per_base_elem: usize,
+}
+
+// Implement HashToField from F and a variable output hash
+impl<F: Field, H: FixedOutput + Digest + Sized + Clone> HashToField<F> for IETFHasher<H> {
+    fn new_hash_to_field(domain: &[u8], count: usize) -> Result<Self, HashToCurveError> {
+        // TODO check whether this is the same as
+        // hasher.update(self.domain).update(self.domain.len() as u8);
+        let mut dst_prime: Vec<u8> = domain.to_vec();
+        dst_prime.push(domain.len() as u8);
+
+        // Create hasher and map the error type
+        let hasher = H::new();
+
+        // Hardcoded security parameter, defined as `k` in:
+        // <https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-10.html#name-security-considerations-3>.
+        // TODO this could be parametrised
+        const SECURITY_PARAMETER: usize = 128;
+
+        // The final output of `hash_to_field` will be an array of field
+        // elements from F::BaseField, each of size `len_per_elem`.
+        let len_per_base_elem = get_len_per_elem::<F, SECURITY_PARAMETER>();
+
+        Ok(IETFHasher {
+            hasher,
+            count,
+            domain: dst_prime,
+            len_per_base_elem,
+        })
+    }
+
+    fn hash_to_field(&self, message: &[u8]) -> Result<Vec<F>, HashToCurveError> {
+        // output size of the hash function, e.g. 32 bytes = 256 bits for sha2::Sha256
+        let b_in_bytes: usize = H::output_size();
+
+        let m = F::extension_degree() as usize;
+
+        // The user imposes a `count` of elements of F_p^m to output per input msg,
+        // each field element comprising `m` BasePrimeField elements.
+        let len_in_bytes = self.count * m * self.len_per_base_elem;
+
+        // total length of output divided by output size of the hash function
+        let ell: usize = (len_in_bytes + b_in_bytes - 1) / b_in_bytes;
+
+        // Input block size of sha256
+        const S_IN_BYTES: usize = 64;
+        // TODO figure this out
+        const l_i_b_str: usize = 128;
+
+        let mut uniform_bytes: Vec<u8> = Vec::with_capacity(len_in_bytes);
+
+        let mut b_0_hasher = self.hasher.clone();
+        b_0_hasher.update(&[0; S_IN_BYTES]);
+        b_0_hasher.update(message);
+        b_0_hasher.update(&[0, (l_i_b_str) as u8]);
+        b_0_hasher.update(&[0]);
+        b_0_hasher.update(&self.domain);
+        let b_0 = b_0_hasher.finalize().to_vec();
+
+        let mut b_1_hasher = self.hasher.clone();
+        b_1_hasher.update(&b_0);
+        b_1_hasher.update(&[1]);
+        b_1_hasher.update(&self.domain);
+        let b_1 = b_1_hasher.finalize().to_vec();
+
+        uniform_bytes.extend(b_1.clone());
+
+        let mut b_i = b_1.clone();
+        for i in 2..=ell {
+            let mut b_i_hasher = self.hasher.clone();
+            // update the hasher with xor of b_0 and b_i elements
+            for (l, r) in b_0.iter().zip(b_i.iter()) {
+                b_i_hasher.update(&[*l ^ *r]);
+            }
+            b_i_hasher.update(&[i as u8]);
+            b_i_hasher.update(&self.domain);
+            // redefine latest b_i
+            b_i = b_i_hasher.finalize().to_vec();
+            uniform_bytes.extend(b_i.clone());
+        }
+
+        let mut output: Vec<F> = Vec::with_capacity(self.count);
+        for i in 0..self.count {
+            let mut base_prime_field_elems: Vec<F::BasePrimeField> = Vec::new();
+            for j in 0..m {
+                let elm_offset = self.len_per_base_elem * (j + i * m);
+                let val: F::BasePrimeField = F::BasePrimeField::from_be_bytes_mod_order(
+                    &uniform_bytes[elm_offset..elm_offset + self.len_per_base_elem],
+                );
+                base_prime_field_elems.push(val);
+            }
+            let f: F = F::from_base_prime_field_elems(&base_prime_field_elems).unwrap();
+            output.push(f);
+        }
+
+        Ok(output)
+    }
+}

--- a/ec/src/hashing/field_hashers/ietf_hasher.rs
+++ b/ec/src/hashing/field_hashers/ietf_hasher.rs
@@ -6,10 +6,9 @@ use digest::{Digest, FixedOutput};
 
 use super::get_len_per_elem;
 
-/// This field hasher constructs a Hash to Field from a variable output hash function.
-/// It handles domains by hashing the input domain into 256 bits, and prefixes
-/// these bits to every message it computes the hash of.
-/// The state after prefixing the domain is cached.
+/// This field hasher constructs a Hash-To-Field based on a fixed-output hash function,
+/// like SHA2, SHA3 or Blake2.
+/// The implementation aims to follow the specification in [Hashing to Elliptic Curves (draft)](https://tools.ietf.org/pdf/draft-irtf-cfrg-hash-to-curve-13.pdf).
 ///
 /// # Examples
 ///
@@ -31,7 +30,6 @@ pub struct IETFHasher<H: FixedOutput + Digest + Sized + Clone> {
     len_per_base_elem: usize,
 }
 
-// Implement HashToField from F and a variable output hash
 impl<F: Field, H: FixedOutput + Digest + Sized + Clone> HashToField<F> for IETFHasher<H> {
     fn new_hash_to_field(domain: &[u8], count: usize) -> Result<Self, HashToCurveError> {
         // TODO check whether this is the same as

--- a/ec/src/hashing/field_hashers/ietf_hasher.rs
+++ b/ec/src/hashing/field_hashers/ietf_hasher.rs
@@ -75,7 +75,7 @@ impl<F: Field, H: FixedOutput + Digest + Sized + Clone> HashToField<F> for IETFH
         // Represent `len_in_bytes` as a 2-byte array.
         // As per I2OSP method outlined in https://tools.ietf.org/pdf/rfc8017.pdf,
         // The program should abort if integer that we're trying to convert is too large.
-        assert!(len_in_bytes < 1<<16);
+        assert!(len_in_bytes < 1 << 16);
         let l_i_b_str: [u8; 2] = (len_in_bytes as u16).to_be_bytes();
 
         let mut uniform_bytes: Vec<u8> = Vec::with_capacity(len_in_bytes);

--- a/ec/src/hashing/field_hashers/ietf_hasher.rs
+++ b/ec/src/hashing/field_hashers/ietf_hasher.rs
@@ -72,15 +72,18 @@ impl<F: Field, H: FixedOutput + Digest + Sized + Clone> HashToField<F> for IETFH
 
         // Input block size of sha256
         const S_IN_BYTES: usize = 64;
-        // TODO figure this out
-        const l_i_b_str: usize = 128;
+        // Represent `len_in_bytes` as a 2-byte array.
+        // As per I2OSP method outlined in https://tools.ietf.org/pdf/rfc8017.pdf,
+        // The program should abort if integer that we're trying to convert is too large.
+        assert!(len_in_bytes < 1<<16);
+        let l_i_b_str: [u8; 2] = (len_in_bytes as u16).to_be_bytes();
 
         let mut uniform_bytes: Vec<u8> = Vec::with_capacity(len_in_bytes);
 
         let mut b_0_hasher = self.hasher.clone();
         b_0_hasher.update(&[0; S_IN_BYTES]);
         b_0_hasher.update(message);
-        b_0_hasher.update(&[0, (l_i_b_str) as u8]);
+        b_0_hasher.update(&l_i_b_str);
         b_0_hasher.update(&[0]);
         b_0_hasher.update(&self.domain);
         let b_0 = b_0_hasher.finalize().to_vec();

--- a/ec/src/hashing/field_hashers/mod.rs
+++ b/ec/src/hashing/field_hashers/mod.rs
@@ -51,7 +51,7 @@ impl<F: Field, H: VariableOutput + Update + Sized + Clone> HashToField<F>
 {
     fn new_hash_to_field(domain: &[u8], count: usize) -> Result<Self, HashToCurveError> {
         // Hardcode security parameter
-        let bytes_per_base_field_elem = hash_len_in_bytes::<F, 128>(security_parameter, count);
+        let bytes_per_base_field_elem = hash_len_in_bytes::<F, 128>(count);
         // Create hasher and map the error type
         let wrapped_hasher = H::new(bytes_per_base_field_elem);
         let mut hasher = match wrapped_hasher {

--- a/ec/src/hashing/field_hashers/mod.rs
+++ b/ec/src/hashing/field_hashers/mod.rs
@@ -13,8 +13,7 @@ fn hash_len_in_bytes<F: Field, const SEC_PARAM: usize>(count: usize) -> usize {
     // ceil(log(p))
     let base_field_size_in_bits = F::BasePrimeField::size_in_bits();
     // ceil(log(p)) + security_parameter
-    let base_field_size_with_security_padding_in_bits =
-        base_field_size_in_bits + SEC_PARAM;
+    let base_field_size_with_security_padding_in_bits = base_field_size_in_bits + SEC_PARAM;
     // ceil( (ceil(log(p)) + security_parameter) / 8)
     let bytes_per_base_field_elem =
         ((base_field_size_with_security_padding_in_bits + 7) / 8) as u64;
@@ -27,9 +26,8 @@ fn map_bytes_to_field_elem<F: Field>(bz: &[u8]) -> Option<F> {
     let len_per_elem = bz.len() / d;
     let mut base_field_elems = Vec::new();
     for i in 0..d {
-        let val = F::BasePrimeField::from_be_bytes_mod_order(
-            &bz[(i * len_per_elem)..][..len_per_elem],
-        );
+        let val =
+            F::BasePrimeField::from_be_bytes_mod_order(&bz[(i * len_per_elem)..][..len_per_elem]);
         base_field_elems.push(val);
     }
     F::from_base_prime_field_elems(&base_field_elems)

--- a/ec/src/hashing/field_hashers/mod.rs
+++ b/ec/src/hashing/field_hashers/mod.rs
@@ -1,15 +1,15 @@
-use ark_ff::{Field, PrimeField};
-use ark_std::vec::Vec;
+mod default_hasher;
+pub use default_hasher::DefaultFieldHasher;
+mod ietf_hasher;
+pub use ietf_hasher::IETFHasher;
 
-use crate::hashing::{map_to_curve_hasher::*, *};
-use ark_std::string::ToString;
-use digest::{Update, VariableOutput};
+use ark_ff::{Field, PrimeField};
 
 // This function computes the length in bytes that a hash function should output
 // for hashing `count` field elements.
 // See section 5.1 and 5.3 of the
 // [IETF hash standardization draft](https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-10)
-fn hash_len_in_bytes<F: Field, const SEC_PARAM: usize>(count: usize) -> usize {
+fn get_len_per_elem<F: Field, const SEC_PARAM: usize>() -> usize {
     // ceil(log(p))
     let base_field_size_in_bits = F::BasePrimeField::size_in_bits();
     // ceil(log(p)) + security_parameter
@@ -17,84 +17,19 @@ fn hash_len_in_bytes<F: Field, const SEC_PARAM: usize>(count: usize) -> usize {
     // ceil( (ceil(log(p)) + security_parameter) / 8)
     let bytes_per_base_field_elem =
         ((base_field_size_with_security_padding_in_bits + 7) / 8) as u64;
-    let len_in_bytes = F::extension_degree() * (count as u64) * bytes_per_base_field_elem;
-    len_in_bytes as usize
+    bytes_per_base_field_elem as usize
 }
 
-fn map_bytes_to_field_elem<F: Field>(bz: &[u8]) -> Option<F> {
-    let d: usize = F::extension_degree() as usize;
-    let len_per_elem = bz.len() / d;
-    let mut base_field_elems = Vec::new();
-    for i in 0..d {
-        let val =
-            F::BasePrimeField::from_be_bytes_mod_order(&bz[(i * len_per_elem)..][..len_per_elem]);
-        base_field_elems.push(val);
-    }
-    F::from_base_prime_field_elems(&base_field_elems)
-}
+#[cfg(test)]
+mod hasher_tests {
+    use super::*;
+    use ark_test_curves::bls12_381::{Fq, Fq2};
 
-// This field hasher constructs a Hash to Field from a variable output hash
-// function. It handles domains by hashing the input domain into 256 bits, and
-// prefixes these bits to every message it computes the hash of.
-// The state after prefixing the domain is cached.
-pub struct DefaultFieldHasher<H: VariableOutput + Update + Sized + Clone> {
-    // This hasher should already have the domain applied to it.
-    domain_seperated_hasher: H,
-    count: usize,
-}
-
-// Implement HashToField from F and a variable output hash
-impl<F: Field, H: VariableOutput + Update + Sized + Clone> HashToField<F>
-    for DefaultFieldHasher<H>
-{
-    fn new_hash_to_field(domain: &[u8], count: usize) -> Result<Self, HashToCurveError> {
-        // Hardcode security parameter
-        let bytes_per_base_field_elem = hash_len_in_bytes::<F, 128>(count);
-        // Create hasher and map the error type
-        let wrapped_hasher = H::new(bytes_per_base_field_elem);
-        let mut hasher = match wrapped_hasher {
-            Ok(hasher) => hasher,
-            Err(err) => return Err(HashToCurveError::DomainError(err.to_string())),
-        };
-
-        // DefaultFieldHasher handles domains by hashing them into 256 bits / 32 bytes
-        // using the same hasher. The hashed domain is then prefixed to all
-        // messages that get hashed.
-        let hashed_domain_length_in_bytes = 32;
-        let mut hashed_domain = [0u8; 32];
-        // Create hasher and map the error type
-        let wrapped_domain_hasher = H::new(hashed_domain_length_in_bytes);
-        let mut domain_hasher = match wrapped_domain_hasher {
-            Ok(hasher) => hasher,
-            Err(err) => return Err(HashToCurveError::DomainError(err.to_string())),
-        };
-
-        domain_hasher.update(domain);
-        domain_hasher.finalize_variable(|res| hashed_domain.copy_from_slice(res));
-
-        // Prefix the 32 byte hashed domain to our hasher
-        hasher.update(&hashed_domain);
-        Ok(DefaultFieldHasher {
-            domain_seperated_hasher: hasher,
-            count,
-        })
-    }
-
-    fn hash_to_field(&self, msg: &[u8]) -> Result<Vec<F>, HashToCurveError> {
-        // Clone the hasher, and hash our message
-        let mut cur_hasher = self.domain_seperated_hasher.clone();
-        cur_hasher.update(msg);
-        let mut hashed_bytes = Vec::new();
-        cur_hasher.finalize_variable(|res| hashed_bytes.extend_from_slice(res));
-        // Now separate the hashed bytes according to each field element.
-        let mut result = Vec::with_capacity(self.count);
-        let len_per_elem = hashed_bytes.len() / self.count;
-        for i in 0..self.count {
-            let bz_per_elem = &hashed_bytes[i * len_per_elem..][..len_per_elem];
-            let val = map_bytes_to_field_elem::<F>(bz_per_elem).unwrap();
-            result.push(val);
-        }
-
-        Ok(result)
+    #[test]
+    fn test_get_len_per_elem() {
+        let fq_len = get_len_per_elem::<Fq, 128>();
+        let fq2_len = get_len_per_elem::<Fq2, 128>();
+        assert_eq!(fq_len, fq2_len);
+        assert_eq!(fq_len, 64);
     }
 }

--- a/ec/src/hashing/map_to_curve_hasher.rs
+++ b/ec/src/hashing/map_to_curve_hasher.rs
@@ -4,6 +4,7 @@ use ark_std::{marker::PhantomData, vec::Vec};
 
 /// Trait for mapping a random field element to a random curve point.
 pub trait MapToCurve<T: AffineCurve> {
+    /// Constructs a new mapping.
     fn new_map_to_curve(domain: &[u8]) -> Result<Self, HashToCurveError>
     where
         Self: Sized;
@@ -11,10 +12,17 @@ pub trait MapToCurve<T: AffineCurve> {
     fn map_to_curve(&self, point: T::BaseField) -> Result<T, HashToCurveError>;
 }
 
-/// Trait for hashing messages to field elements
+/// Trait for hashing messages to field elements.
 pub trait HashToField<F: Field>: Sized {
+    /// Initialises a new hash-to-field helper struct.
+    ///
+    /// # Arguments
+    ///
+    /// * `domain` - bytes that get concatenated with the `msg` during hashing, in order to separate potentially interfering instantiations of the hasher.
+    /// * `count` - number of elements in field `F` to output.
     fn new_hash_to_field(domain: &[u8], count: usize) -> Result<Self, HashToCurveError>;
 
+    /// Hash an arbitrary `msg` to #`count` elements from field `F`.
     fn hash_to_field(&self, msg: &[u8]) -> Result<Vec<F>, HashToCurveError>;
 }
 

--- a/ec/src/hashing/tests.rs
+++ b/ec/src/hashing/tests.rs
@@ -1,3 +1,4 @@
+use crate::hashing::HashToCurve;
 use crate::{
     hashing::{
         curve_maps::{
@@ -6,7 +7,6 @@ use crate::{
         },
         field_hashers::DefaultFieldHasher,
         map_to_curve_hasher::{MapToCurve, MapToCurveBasedHasher},
-        HashToCurve,
     },
     models::SWModelParameters,
     short_weierstrass_jacobian::GroupAffine,


### PR DESCRIPTION
Based on my [older work](https://github.com/mmagician/algebra/tree/mmagician/cosmetic-fixes), but rebased on top of more recent work: #21 should be merged first, since this work branched off the tip of #21.

## Description

- Add a field hasher compatible with IETF specifications.
- The DefaultHasher previously available is moved from `mod.rs` to its own file `default_hasher.rs`.
- IETFHasher is placed in its own file too.
- Both hashers are exposed directly in the `field_hashers` module, so that instead of calling:
```
use field_hashers::default_hasher::DefaultHasher;
```

You can directly import the hasher:
```
use field_hashers::DefaultHasher;
```

- Previous unit tests using DefaultHasher pass.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
