### PR TITLE
Remove domain from curve maps

### DIFF
--- a/ec/src/hashing/README.md
+++ b/ec/src/hashing/README.md
@@ -1,3 +1,0 @@
-# Hash to Curve
-
-This folder provides a trait for `HashToCurve` and a number of implementations of hashing to the curve.

--- a/ec/src/hashing/curve_maps/swu/mod.rs
+++ b/ec/src/hashing/curve_maps/swu/mod.rs
@@ -28,13 +28,12 @@ pub trait SWUParams: SWModelParameters {
 
 /// Represents the SWU hash-to-curve map defined by `P`.
 pub struct SWUMap<P: SWUParams> {
-    pub domain: Vec<u8>,
     curve_params: PhantomData<fn() -> P>,
 }
 
 impl<P: SWUParams> MapToCurve<GroupAffine<P>> for SWUMap<P> {
     /// Constructs a new map if `P` represents a valid map.
-    fn new_map_to_curve(domain: &[u8]) -> Result<Self, HashToCurveError> {
+    fn new_map_to_curve() -> Result<Self, HashToCurveError> {
         // Verifying that both XI and ZETA are non-squares
         if P::XI.legendre().is_qr() || P::ZETA.legendre().is_qr() {
             return Err(HashToCurveError::MapToCurveError(
@@ -66,7 +65,6 @@ impl<P: SWUParams> MapToCurve<GroupAffine<P>> for SWUMap<P> {
         }
 
         Ok(SWUMap {
-            domain: domain.to_vec(),
             curve_params: PhantomData,
         })
     }

--- a/ec/src/hashing/curve_maps/swu/mod.rs
+++ b/ec/src/hashing/curve_maps/swu/mod.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use ark_ff::bytes::{ToBytes};
+use ark_ff::bytes::ToBytes;
 
 use crate::models::SWModelParameters;
 use ark_ff::{vec::Vec, Field, One, SquareRootField, Zero};
@@ -9,7 +9,6 @@ use ark_std::string::ToString;
 use crate::{
     hashing::{map_to_curve_hasher::MapToCurve, HashToCurveError},
     models::short_weierstrass_jacobian::GroupAffine,
-    AffineCurve,
 };
 
 /// Trait defining the necessary parameters for the SWU hash-to-curve method
@@ -49,7 +48,8 @@ impl<P: SWUParams> MapToCurve<GroupAffine<P>> for SWUMap<P> {
             Some(xi_on_zeta_sqrt) => {
                 if xi_on_zeta_sqrt != P::XI_ON_ZETA_SQRT && xi_on_zeta_sqrt != -P::XI_ON_ZETA_SQRT {
                     return Err(HashToCurveError::MapToCurveError(
-                        "precomputed P::XI_ON_ZETA_SQRT is not what it is supposed to be".to_string(),
+                        "precomputed P::XI_ON_ZETA_SQRT is not what it is supposed to be"
+                            .to_string(),
                     ));
                 }
             }
@@ -74,10 +74,7 @@ impl<P: SWUParams> MapToCurve<GroupAffine<P>> for SWUMap<P> {
     /// Map an arbitrary base field element to a curve point.
     /// Based on
     /// <https://github.com/zcash/pasta_curves/blob/main/src/hashtocurve.rs>.
-    fn map_to_curve(
-        &self,
-        point: P::BaseField,
-    ) -> Result<GroupAffine<P>, HashToCurveError> {
+    fn map_to_curve(&self, point: P::BaseField) -> Result<GroupAffine<P>, HashToCurveError> {
         // 1. tv1 = inv0(Z^2 * u^4 + Z * u^2)
         // 2. x1 = (-B / A) * (1 + tv1)
         // 3. If tv1 == 0, set x1 = B / (Z * A)
@@ -159,14 +156,13 @@ impl<P: SWUParams> MapToCurve<GroupAffine<P>> for SWUMap<P> {
         let num_x = if gx1_square { num_x1 } else { num_x2 };
         let y = if gx1_square { y1 } else { y2 };
 
-        
         let x_affine = num_x / div;
         // 9. If sgn0(u) != sgn0(y), set y = -y
         let mut a = [0u8; 128];
-        let mut b =  [0u8; 128];
+        let mut b = [0u8; 128];
         point.write(&mut a[..]).unwrap();
         y.write(&mut b[..]).unwrap();
-        let y_affine = if a[0] % 2 == b[0] % 2 { -y } else {y};
+        let y_affine = if a[0] % 2 == b[0] % 2 { -y } else { y };
         let point_on_curve = GroupAffine::<P>::new(x_affine, y_affine, false);
         assert!(
             point_on_curve.is_on_curve(),

--- a/ec/src/hashing/curve_maps/wb/mod.rs
+++ b/ec/src/hashing/curve_maps/wb/mod.rs
@@ -25,18 +25,6 @@ type BaseField<MP> = <MP as ModelParameters>::BaseField;
 pub trait WBParams: SWModelParameters + Sized {
     // The isogenous curve should be defined over the same base field but it can have
     // different scalar field type IsogenousCurveScalarField :
-/// Trait defining the necessary parameters for the WB hash-to-curve method
-/// for the curves of Weierstrass form of:
-/// of y^2 = x^3 + a*x + b where b != 0 but `a` can be zero like BLS-381 curve.
-/// From [WB2019]
-///
-/// - [WB19] Wahby, R. S., & Boneh, D. (2019). Fast and simple constant-time
-///   hashing to the bls12-381 elliptic curve. IACR Transactions on
-///   Cryptographic Hardware and Embedded Systems, nil(nil), 154–179.
-///   http://dx.doi.org/10.46586/tches.v2019.i4.154-179
-pub trait WBParams: SWModelParameters + Sized {
-    // The isogenous curve should be defined over the same base field but it can have
-    // different scalar field type IsogenousCurveScalarField :
     type IsogenousCurve: SWUParams<BaseField = BaseField<Self>>;
 
     const PHI_X_NOM: &'static [BaseField<Self>];

--- a/ec/src/hashing/curve_maps/wb/mod.rs
+++ b/ec/src/hashing/curve_maps/wb/mod.rs
@@ -55,14 +55,13 @@ pub trait WBParams: SWModelParameters + Sized {
 }
 
 pub struct WBMap<P: WBParams> {
-    pub domain: Vec<u8>,
     swu_field_curve_hasher: SWUMap<P::IsogenousCurve>,
     curve_params: PhantomData<fn() -> P>,
 }
 
 impl<P: WBParams> MapToCurve<GroupAffine<P>> for WBMap<P> {
     /// Constructs a new map if `P` represents a valid map.
-    fn new_map_to_curve(domain: &[u8]) -> Result<Self, HashToCurveError> {
+    fn new_map_to_curve() -> Result<Self, HashToCurveError> {
         // Verifying that the isogeny maps the generator of the SWU curve into us
         let isogenous_curve_generator = GroupAffine::<P::IsogenousCurve>::new(
             P::IsogenousCurve::AFFINE_GENERATOR_COEFFS.0,
@@ -80,8 +79,7 @@ impl<P: WBParams> MapToCurve<GroupAffine<P>> for WBMap<P> {
         }
 
         Ok(WBMap {
-            domain: domain.to_vec(),
-            swu_field_curve_hasher: SWUMap::<P::IsogenousCurve>::new_map_to_curve(&domain).unwrap(),
+            swu_field_curve_hasher: SWUMap::<P::IsogenousCurve>::new_map_to_curve().unwrap(),
             curve_params: PhantomData,
         })
     }

--- a/ec/src/hashing/field_hashers/mod.rs
+++ b/ec/src/hashing/field_hashers/mod.rs
@@ -51,7 +51,7 @@ impl<F: Field, H: VariableOutput + Update + Sized + Clone> HashToField<F>
 {
     fn new_hash_to_field(domain: &[u8], count: usize) -> Result<Self, HashToCurveError> {
         // Hardcode security parameter
-        let bytes_per_base_field_elem = hash_len_in_bytes::<F, 128>(security_parameter, count);
+        let bytes_per_base_field_elem = hash_len_in_bytes::<F, 128>(count);
         // Create hasher and map the error type
         let wrapped_hasher = H::new(bytes_per_base_field_elem);
         let mut hasher = match wrapped_hasher {

--- a/ec/src/hashing/field_hashers/mod.rs
+++ b/ec/src/hashing/field_hashers/mod.rs
@@ -13,8 +13,7 @@ fn hash_len_in_bytes<F: Field, const SEC_PARAM: usize>(count: usize) -> usize {
     // ceil(log(p))
     let base_field_size_in_bits = F::BasePrimeField::size_in_bits();
     // ceil(log(p)) + security_parameter
-    let base_field_size_with_security_padding_in_bits =
-        base_field_size_in_bits + SEC_PARAM;
+    let base_field_size_with_security_padding_in_bits = base_field_size_in_bits + SEC_PARAM;
     // ceil( (ceil(log(p)) + security_parameter) / 8)
     let bytes_per_base_field_elem =
         ((base_field_size_with_security_padding_in_bits + 7) / 8) as u64;
@@ -27,9 +26,8 @@ fn map_bytes_to_field_elem<F: Field>(bz: &[u8]) -> Option<F> {
     let len_per_elem = bz.len() / d;
     let mut base_field_elems = Vec::new();
     for i in 0..d {
-        let val = F::BasePrimeField::from_be_bytes_mod_order(
-            &bz[(i * len_per_elem)..][..len_per_elem],
-        );
+        let val =
+            F::BasePrimeField::from_be_bytes_mod_order(&bz[(i * len_per_elem)..][..len_per_elem]);
         base_field_elems.push(val);
     }
     F::from_base_prime_field_elems(&base_field_elems)

--- a/ec/src/hashing/map_to_curve_hasher.rs
+++ b/ec/src/hashing/map_to_curve_hasher.rs
@@ -5,7 +5,7 @@ use ark_std::{marker::PhantomData, vec::Vec};
 /// Trait for mapping a random field element to a random curve point.
 pub trait MapToCurve<T: AffineCurve> {
     /// Constructs a new mapping.
-    fn new_map_to_curve(domain: &[u8]) -> Result<Self, HashToCurveError>
+    fn new_map_to_curve() -> Result<Self, HashToCurveError>
     where
         Self: Sized;
     /// Map random field point to a random curve point
@@ -48,7 +48,7 @@ where
 {
     fn new(domain: &[u8]) -> Result<Self, HashToCurveError> {
         let field_hasher = H2F::new_hash_to_field(domain, 2)?;
-        let curve_mapper = M2C::new_map_to_curve(domain)?;
+        let curve_mapper = M2C::new_map_to_curve()?;
         let _params_t = PhantomData;
         Ok(MapToCurveBasedHasher {
             field_hasher,

--- a/ec/src/hashing/map_to_curve_hasher.rs
+++ b/ec/src/hashing/map_to_curve_hasher.rs
@@ -4,6 +4,7 @@ use ark_std::{marker::PhantomData, vec::Vec};
 
 /// Trait for mapping a random field element to a random curve point.
 pub trait MapToCurve<T: AffineCurve> {
+    /// Constructs a new mapping.
     fn new_map_to_curve(domain: &[u8]) -> Result<Self, HashToCurveError>
     where
         Self: Sized;
@@ -11,10 +12,17 @@ pub trait MapToCurve<T: AffineCurve> {
     fn map_to_curve(&self, point: T::BaseField) -> Result<T, HashToCurveError>;
 }
 
-/// Trait for hashing messages to field elements
+/// Trait for hashing messages to field elements.
 pub trait HashToField<F: Field>: Sized {
+    /// Initialises a new hash-to-field helper struct.
+    ///
+    /// # Arguments
+    ///
+    /// * `domain` - bytes that get concatenated with the `msg` during hashing, in order to separate potentially interfering instantiations of the hasher.
+    /// * `count` - number of elements in field `F` to output.
     fn new_hash_to_field(domain: &[u8], count: usize) -> Result<Self, HashToCurveError>;
 
+    /// Hash an arbitrary `msg` to #`count` elements from field `F`.
     fn hash_to_field(&self, msg: &[u8]) -> Result<Vec<F>, HashToCurveError>;
 }
 

--- a/ec/src/hashing/tests.rs
+++ b/ec/src/hashing/tests.rs
@@ -199,7 +199,7 @@ fn hash_arbitary_string_to_curve_swu() {
 /// elements should be mapped to curve successfully. everything can be mapped
 #[test]
 fn map_field_to_curve_swu() {
-    let test_map_to_curve = SWUMap::<TestSWUMapToCurveParams>::new_map_to_curve(&[0]).unwrap();
+    let test_map_to_curve = SWUMap::<TestSWUMapToCurveParams>::new_map_to_curve().unwrap();
 
     let mut map_range: Vec<GroupAffine<TestSWUMapToCurveParams>> = vec![];
     for current_field_element in 0..127 {


### PR DESCRIPTION
## Description

Domain separation tag (DST) is only used for the hash-to-field step, not the map-to-curve step. This PR is removing it from the latter.

This PR has branched off from #21, so #21 should be merged first.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
