### PR TITLE
Unstable feature: const generic domain

### DIFF
--- a/ec/src/hashing/field_hashers/mod.rs
+++ b/ec/src/hashing/field_hashers/mod.rs
@@ -44,10 +44,10 @@ pub struct DefaultFieldHasher<H: VariableOutput + Update + Sized + Clone> {
 }
 
 // Implement HashToField from F and a variable output hash
-impl<F: Field, H: VariableOutput + Update + Sized + Clone> HashToField<F>
-    for DefaultFieldHasher<H>
+impl<F: Field, H: VariableOutput + Update + Sized + Clone, const DOMAIN: &'static [u8]>
+    HashToField<F, DOMAIN> for DefaultFieldHasher<H>
 {
-    fn new_hash_to_field(domain: &[u8], count: usize) -> Result<Self, HashToCurveError> {
+    fn new_hash_to_field(count: usize) -> Result<Self, HashToCurveError> {
         // Hardcode security parameter
         let bytes_per_base_field_elem = hash_len_in_bytes::<F, 128>(count);
         // Create hasher and map the error type
@@ -69,7 +69,7 @@ impl<F: Field, H: VariableOutput + Update + Sized + Clone> HashToField<F>
             Err(err) => return Err(HashToCurveError::DomainError(err.to_string())),
         };
 
-        domain_hasher.update(domain);
+        domain_hasher.update(DOMAIN);
         domain_hasher.finalize_variable(|res| hashed_domain.copy_from_slice(res));
 
         // Prefix the 32 byte hashed domain to our hasher

--- a/ec/src/hashing/mod.rs
+++ b/ec/src/hashing/mod.rs
@@ -10,7 +10,7 @@ pub mod field_hashers;
 /// Trait for hashing arbitrary data to a group element on an elliptic curve
 pub trait HashToCurve<T: AffineCurve>: Sized {
     /// Create a new hash to curve instance, with a given domain.
-    fn new(domain: &[u8]) -> Result<Self, HashToCurveError>;
+    fn new() -> Result<Self, HashToCurveError>;
 
     /// Produce a hash of the message, which also depends on the domain.
     /// The output of the hash is a curve point in the prime order subgroup

--- a/ec/src/hashing/tests.rs
+++ b/ec/src/hashing/tests.rs
@@ -183,7 +183,8 @@ fn hash_arbitary_string_to_curve_swu() {
         GroupAffine<TestSWUMapToCurveParams>,
         DefaultFieldHasher<VarBlake2b>,
         SWUMap<TestSWUMapToCurveParams>,
-    >::new(&[1])
+        { &[1] },
+    >::new()
     .unwrap();
 
     let hash_result = test_swu_to_curve_hasher.hash(b"if you stick a Babel fish in your ear you can instantly understand anything said to you in any form of language.").expect("fail to hash the string to curve");
@@ -406,7 +407,8 @@ fn hash_arbitary_string_to_curve_wb() {
         GroupAffine<TestWBF127MapToCurveParams>,
         DefaultFieldHasher<VarBlake2b>,
         WBMap<TestWBF127MapToCurveParams>,
-    >::new(&[1])
+        { &[1] },
+    >::new()
     .unwrap();
 
     let hash_result = test_wb_to_curve_hasher.hash(b"if you stick a Babel fish in your ear you can instantly understand anything said to you in any form of language.").expect("fail to hash the string to curve");

--- a/ec/src/lib.rs
+++ b/ec/src/lib.rs
@@ -12,6 +12,7 @@
     clippy::suspicious_op_assign_impl,
     clippy::many_single_char_names
 )]
+#![feature(adt_const_params)]
 
 #[macro_use]
 extern crate derivative;


### PR DESCRIPTION
## Description

This addresses the replacement of Vec with const, as per [this comment](https://github.com/arkworks-rs/algebra/pull/343#discussion_r767247165) (@Pratyush is this what you meant?). Unfortunately, right now const generic parameter type of `&'static [u8]` is only available on nightly under the `adt_const_params` feature.
We should probably leave this PR out for now, but I am opening a draft for future reference.

---
Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
