### PR TITLE
Parity trait

### DIFF
--- a/ec/src/hashing/tests.rs
+++ b/ec/src/hashing/tests.rs
@@ -1,7 +1,7 @@
 use crate::{
     hashing::{
         curve_maps::{
-            swu::{SWUMap, SWUParams, parity},
+            swu::{SWUMap, SWUParams},
             wb::{WBMap, WBParams},
         },
         field_hashers::DefaultFieldHasher,
@@ -21,10 +21,6 @@ use ark_ff::{
 use ark_ff::SquareRootField;
 use ark_std::vec::Vec;
 use hashbrown::HashMap;
-
-use ark_test_curves::{
-    bls12_381::{Fq, Fq2, Fq6},
-};
 
 pub type F127 = Fp64<F127Parameters>;
 
@@ -424,36 +420,4 @@ fn hash_arbitary_string_to_curve_wb() {
         hash_result.is_on_curve(),
         "hash results into a point off the curve"
     );
-}
-
-#[test]
-fn test_parity() {
-    let a1 = Fq2::new(Fq::from(0), Fq::from(0));
-    let a2 = Fq2::new(Fq::from(0), Fq::from(1));
-    let a3 = Fq2::new(Fq::from(1), Fq::from(0));
-    let a4 = Fq2::new(Fq::from(1), Fq::from(1));
-    let element_test1 = Fq6::new(a1, a2, a3);
-    let element_test2 = Fq6::new(a2, a3, a4);
-    let element_test3 = Fq6::new(a3, a4, a1);
-    let element_test4 = Fq6::new(a4, a1, a2);
-    assert_eq!(parity(&element_test1), false);
-    assert_eq!(parity(&element_test2), false);
-    assert_eq!(parity(&element_test3), true);
-    assert_eq!(parity(&element_test4), true);
-
-    let element_test1 = Fq2::new(Fq::from(0), Fq::from(1));
-    let element_test2 = Fq2::new(Fq::from(1), Fq::from(0));
-    let element_test3 = Fq2::new(Fq::from(10), Fq::from(5));
-    let element_test4 = Fq2::new(Fq::from(5), Fq::from(10));
-    assert_eq!(parity(&element_test1), false);
-    assert_eq!(parity(&element_test2), true);
-    assert_eq!(parity(&element_test3), false);
-    assert_eq!(parity(&element_test4), true);
-
-    let a1 = Fq::from(0);
-    let a2 = Fq::from(1);
-    let a3 = Fq::from(10);
-    assert_eq!(parity(&a1), false);
-    assert_eq!(parity(&a2), true);
-    assert_eq!(parity(&a3), false); 
 }

--- a/ff/src/fields/mod.rs
+++ b/ff/src/fields/mod.rs
@@ -710,7 +710,7 @@ mod no_std_tests {
         bls12_381::{Fr, FrParameters},
         BigInteger, FpParameters, PrimeField,
     };
-    
+
     #[test]
     fn test_batch_inversion() {
         let mut random_coeffs = Vec::<Fr>::new();

--- a/ff/src/fields/models/cubic_extension.rs
+++ b/ff/src/fields/models/cubic_extension.rs
@@ -715,5 +715,5 @@ mod cube_ext_tests {
             let expected = Fq6::new(expected_0, expected_1, expected_2);
             assert_eq!(actual, expected);
         }
-    }   
+    }
 }


### PR DESCRIPTION
Move the parity method to a private trait that is then implemented (with the default implementation) for the SWUMap.

This achieves a few goals:
1. It makes the `parity()` method contained within the SWU module.
2. Allows for an easy refactor, should `parity()` be ever needed in a wider context in the future.
3. Tests for parity can be contained in SWU module as well.

## Description

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
