### PR TITLE
Use BigInt::new instead of the typ BigInteger64

### DIFF
--- a/ec/src/hashing/tests.rs
+++ b/ec/src/hashing/tests.rs
@@ -13,6 +13,7 @@ use crate::{
     ModelParameters,
 };
 use ark_ff::{
+    biginteger::BigInt,
     biginteger::BigInteger64,
     field_new,
     fields::{FftParameters, Fp64, Fp64Parameters, FpParameters},
@@ -36,13 +37,13 @@ impl FftParameters for F127Parameters {
     // sage: FF(3)^63
     // 126
     #[rustfmt::skip]
-    const TWO_ADIC_ROOT_OF_UNITY: BigInteger64 = BigInteger64([126]);
+    const TWO_ADIC_ROOT_OF_UNITY: BigInteger64 = BigInt::new([126]);
 }
 
 impl FpParameters for F127Parameters {
     /// MODULUS = 127
     #[rustfmt::skip]
-    const MODULUS: BigInteger64 = BigInteger64([127]);
+    const MODULUS: BigInteger64 = BigInt::new([127]);
 
     const MODULUS_BITS: u32 = 7;
 
@@ -54,11 +55,11 @@ impl FpParameters for F127Parameters {
     // sage: FF(2^64)
     // 2
     #[rustfmt::skip]
-    const R: BigInteger64 = BigInteger64([2]);
+    const R: BigInteger64 = BigInt::new([2]);
 
     /// R2 = R^2 % Self::MODULUS
     #[rustfmt::skip]
-    const R2: BigInteger64 = BigInteger64([4]);
+    const R2: BigInteger64 = BigInt::new([4]);
 
     /// INV = -MODULUS^{-1} mod 2^64
     // sage: R = Integers(2^64)
@@ -76,11 +77,11 @@ impl FpParameters for F127Parameters {
     // Montgomery conversion 3 * 2 = 6 % 127
     /// GENERATOR = 3
     #[rustfmt::skip]
-    const GENERATOR: BigInteger64 = BigInteger64([6]);
+    const GENERATOR: BigInteger64 = BigInt::new([6]);
 
     /// (Self::MODULUS - 1) / 2
     #[rustfmt::skip]
-    const MODULUS_MINUS_ONE_DIV_TWO: BigInteger64 = BigInteger64([63]);
+    const MODULUS_MINUS_ONE_DIV_TWO: BigInteger64 = BigInt::new([63]);
 
     // T and T_MINUS_ONE_DIV_TWO, where MODULUS - 1 = 2^S * T
     // For T coprime to 2
@@ -93,11 +94,11 @@ impl FpParameters for F127Parameters {
     // sage: (127-1)/2
     // 63
     #[rustfmt::skip]
-    const T: BigInteger64 = BigInteger64([63]);
+    const T: BigInteger64 = BigInt::new([63]);
 
     // (T - 1) / 2 = (63 - 1)/2
     #[rustfmt::skip]
-    const T_MINUS_ONE_DIV_TWO: BigInteger64 = BigInteger64([31]);
+    const T_MINUS_ONE_DIV_TWO: BigInteger64 = BigInt::new([31]);
 }
 
 const F127_ZERO: F127 = field_new!(F127, "0");


### PR DESCRIPTION
Following a move of bigint to const generics

## Description

Fix the problem following an upstream refactor

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
